### PR TITLE
Add call stack information (and more)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,7 @@ Assuming RSpec, edit `spec/spec_helper.rb`:
 
   FactoryInspector.instrument
   RSpec.configure do |config|
-
-    config.before :suite do
-      factory_inspector.start_inspection
-    end
-
-    config.after :suite do
-      FactoryInspector.generate_report
-    end
+    config.after(:suite) { FactoryInspector.results }
   end
 ```
 

--- a/lib/factory_inspector.rb
+++ b/lib/factory_inspector.rb
@@ -1,14 +1,20 @@
-require 'factory_inspector/configuration'
 require 'factory_inspector/inspector'
 
-# Inspects Factories while running and generates reports
+# User facing API
 module FactoryInspector
   def self.instrument
     @inspector ||= Inspector.new
+    true
   end
 
-  def self.generate_report(filename: Configuration.default_report_path)
-    @inspector.generate_summary
-    @inspector.generate_report filename
+  def self.results
+    if @inspector.nil?
+      warn 'WARNING: No FactoryInspector instrumentation found; ' \
+           "did you forget to call 'FactoryInspector.instrument'?"
+    else
+      @inspector.generate_summary
+      @inspector.generate_report
+    end
+    true
   end
 end

--- a/lib/factory_inspector/report.rb
+++ b/lib/factory_inspector/report.rb
@@ -1,57 +1,68 @@
 module FactoryInspector
   # Report on how a FactoryGirl Factory was used in a test run.
   # Holds simple metrics and can be updated with new calls.
+  #
+  # All times are in seconds.
   class Report
     include Comparable
 
     attr_reader :factory_name,
                 :calls,
-                :worst_time_in_seconds,
-                :total_time_in_seconds,
-                :strategies
+                :worst_time,
+                :total_time,
+                :strategies,
+                :callers
 
     def initialize(factory_name: 'unknown')
       @factory_name = factory_name
       @calls = 0
-      @worst_time_in_seconds = 0
-      @total_time_in_seconds = 0
+      @worst_time = 0
+      @total_time = 0
       @strategies = Set.new
+      @callers = []
     end
 
-    def time_per_call_in_seconds
-      (@calls == 0) ? 0 : (@total_time_in_seconds.to_f / @calls.to_f)
+    def all_calls
+      callers.map do |stack|
+        stack.join(' -> ').gsub(/\A/,'    ')
+      end.join("\n") + "\n"
+    end
+
+    def time_per_call
+      (@calls == 0) ? 0 : (@total_time.to_f / @calls.to_f)
     end
 
     # Update this report with a new factory call
     # * [time] The time taken, in seconds, to call the factory
     # * [strategy] The strategy used by the factory
-    def update(time: 0, strategy: '')
+    def update(time: 0, strategy: '', call_stack: [])
       @calls += 1
       record_time(time: time)
       @strategies << strategy.to_s
+      @callers << call_stack
     end
 
     def <=>(other)
-      time_per_call_in_seconds <=> other.time_per_call_in_seconds
+      time_per_call <=> other.time_per_call
     end
 
     def to_s
       format("  %-30.30s % 5.0d    %8.4f    %5.5f  %5.4f      %s\n",
              factory_name,
              calls,
-             total_time_in_seconds,
-             time_per_call_in_seconds,
-             worst_time_in_seconds,
+             total_time,
+             time_per_call,
+             worst_time,
              strategies.to_a.join(', '))
     end
 
     private
 
     def record_time(time: 0)
-      if time > @worst_time_in_seconds
-        @worst_time_in_seconds = time
+      if time > @worst_time
+        @worst_time = time
       end
-      @total_time_in_seconds += time
+      @total_time += time
     end
   end
 end


### PR DESCRIPTION
A more useful tool would:
- In the log file, print the complete set of call stacks for each factory
- Have a nicer API
- Tolerate user error
- Look nicer
