### PR TITLE
Write (many) warnings to log, not stderr

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    factory_inspector (0.2.0)
+    factory_inspector (0.3.0)
       activesupport
       chronic_duration
       term-ansicolor

--- a/lib/factory_inspector.rb
+++ b/lib/factory_inspector.rb
@@ -14,6 +14,7 @@ module FactoryInspector
     else
       @inspector.generate_summary
       @inspector.generate_report
+      @inspector.generate_warnings_log
     end
     true
   end

--- a/lib/factory_inspector/configuration.rb
+++ b/lib/factory_inspector/configuration.rb
@@ -5,8 +5,16 @@ module FactoryInspector
       File.expand_path default_report_file, root_path
     end
 
+    def self.default_warnings_log_path
+      File.expand_path default_warnings_log_file, root_path
+    end
+
     def self.default_report_file
-      'log/factory_inspector.txt'
+      'log/factory_inspector.log'
+    end
+
+    def self.default_warnings_log_file
+      'log/factory_inspector_warnings.log'
     end
 
     def self.root_path


### PR DESCRIPTION
When used on a live project there were so many Timecop freeze warnings that it was spam. Put them in a file and try and identify the line number where it happens.
